### PR TITLE
Error messages is not defined fix

### DIFF
--- a/config/freenom.js
+++ b/config/freenom.js
@@ -88,6 +88,7 @@ const freenom = {
       })
 
       let message = ``
+      let messages = []
       let i = 1
       await Promise.all(domains.map(async domain => {
         const id = domain.renewLink.replace('https://my.freenom.com/domains.php?a=renewdomain&domain=', '')


### PR DESCRIPTION
Fixes error
```
 [renew] Error ReferenceError: messages is not defined
    at /home/container/config/freenom.js:122:9
    at async Promise.all (index 0)
    at async Object.renewFreeDomains (/home/container/config/freenom.js:92:7)
    at async Object.init (/home/container/config/freenom.js:48:7)
    at async run (/home/container/app.js:14:3)
Scrap finished for https://my.freenom.com/domains.php?a=renewals
```
